### PR TITLE
Add unified multi-machine dataset support

### DIFF
--- a/01_train_2025t2.sh
+++ b/01_train_2025t2.sh
@@ -28,27 +28,10 @@ job="train_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyCar \
-        DCASE2025T2ToyTrain \
-        DCASE2025T2bearing \
-        DCASE2025T2fan \
-        DCASE2025T2gearbox \
-        DCASE2025T2slider \
-        DCASE2025T2valve \
-    "
+    dataset_list="DCASE2025T2All"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyRCCar \
-        DCASE2025T2ToyPet \
-        DCASE2025T2HomeCamera \
-        DCASE2025T2AutoTrash \
-        DCASE2025T2Polisher \
-        DCASE2025T2ScrewFeeder \
-        DCASE2025T2BandSealer \
-        DCASE2025T2CoffeeGrinder \
-    "
+    dataset_list="DCASE2025T2All"
 fi
 
 for dataset in $dataset_list; do

--- a/02a_test_2025t2.sh
+++ b/02a_test_2025t2.sh
@@ -28,15 +28,7 @@ job="test_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyCar \
-        DCASE2025T2ToyTrain \
-        DCASE2025T2bearing \
-        DCASE2025T2fan \
-        DCASE2025T2gearbox \
-        DCASE2025T2slider \
-        DCASE2025T2valve \
-    "
+    dataset_list="DCASE2025T2All"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
     echo dcase2025 task2 eval data are not publish

--- a/02b_test_2025t2.sh
+++ b/02b_test_2025t2.sh
@@ -28,15 +28,7 @@ job="test_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyCar \
-        DCASE2025T2ToyTrain \
-        DCASE2025T2bearing \
-        DCASE2025T2fan \
-        DCASE2025T2gearbox \
-        DCASE2025T2slider \
-        DCASE2025T2valve \
-    "
+    dataset_list="DCASE2025T2All"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
     echo dcase2025 task2 eval data are not publish


### PR DESCRIPTION
## Summary
- implement `DCASE202XT2All` dataset that concatenates all machine types
- add new dataset option `DCASE2025T2All`
- update training and testing scripts to use the new dataset

## Testing
- `python3 -m py_compile datasets/datasets.py`
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683dc5b61bb88331b53e3123e1245f5e