### PR TITLE
Fix meta learner adaptation

### DIFF
--- a/networks/dcase2025_multi_branch/dcase2025_multi_branch.py
+++ b/networks/dcase2025_multi_branch/dcase2025_multi_branch.py
@@ -318,15 +318,14 @@ class DCASE2025MultiBranch(BaseModel):
             test_batches = list(test_loader)
             support_batches = test_batches[: self.maml_shots]
             losses = []
-            with torch.no_grad():
-                for batch in support_batches:
-                    feats = batch[0].to(device).float()
-                    labels = torch.argmax(batch[2], dim=1).long().to(device)
-                    b, dim = feats.shape
-                    frames = dim // self.cfg["n_mels"]
-                    feats = feats.view(b, 1, self.cfg["n_mels"], frames)
-                    _, _, _, sc_tmp = self.forward(feats, labels)
-                    losses.append(sc_tmp.mean())
+            for batch in support_batches:
+                feats = batch[0].to(device).float()
+                labels = torch.argmax(batch[2], dim=1).long().to(device)
+                b, dim = feats.shape
+                frames = dim // self.cfg["n_mels"]
+                feats = feats.view(b, 1, self.cfg["n_mels"], frames)
+                _, _, _, sc_tmp = self.forward(feats, labels)
+                losses.append(sc_tmp.mean())
             adapted_fusion = self.meta_learner.adapt(losses)[-1] if losses else self.fusion
 
             print("\n============== BEGIN TEST FOR A SECTION ==============")


### PR DESCRIPTION
## Summary
- ensure gradients are available for meta-learner adaptation

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e553f3bdc83319c29475a9c574ca8