### PR TITLE
Fix meta learner adaptation

### DIFF
--- a/networks/dcase2025_multi_branch/dcase2025_multi_branch.py
+++ b/networks/dcase2025_multi_branch/dcase2025_multi_branch.py
@@ -317,17 +317,16 @@ class DCASE2025MultiBranch(BaseModel):
             # ----- Meta-Learner adaptation on support shots -----
             test_batches = list(test_loader)
             support_batches = test_batches[: self.maml_shots]
-            losses = []
-            with torch.no_grad():
-                for batch in support_batches:
-                    feats = batch[0].to(device).float()
-                    labels = torch.argmax(batch[2], dim=1).long().to(device)
-                    b, dim = feats.shape
-                    frames = dim // self.cfg["n_mels"]
-                    feats = feats.view(b, 1, self.cfg["n_mels"], frames)
-                    _, _, _, sc_tmp = self.forward(feats, labels)
-                    losses.append(sc_tmp.mean())
-            adapted_fusion = self.meta_learner.adapt(losses)[-1] if losses else self.fusion
+            learner = self.meta_learner.maml.clone()
+            for batch in support_batches:
+                feats = batch[0].to(device).float()
+                labels = torch.argmax(batch[2], dim=1).long().to(device)
+                b, dim = feats.shape
+                frames = dim // self.cfg["n_mels"]
+                feats = feats.view(b, 1, self.cfg["n_mels"], frames)
+                _, _, _, sc_tmp = self.forward(feats, labels, fusion_module=learner.module)
+                learner.adapt(sc_tmp.mean())
+            adapted_fusion = learner.module if support_batches else self.fusion
 
             print("\n============== BEGIN TEST FOR A SECTION ==============")
             with torch.no_grad():


### PR DESCRIPTION
## Summary
- ensure gradients are computed using a cloned learner during test-time adaptation

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e553f3bdc83319c29475a9c574ca8