### PR TITLE
Add contrastive data augmentations

### DIFF
--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -5,6 +5,7 @@ import sys
 
 from datasets.loader_common import get_machine_type_dict
 from datasets.dcase_dcase202x_t2_loader import DCASE202XT2Loader
+from datasets.dual_augment import DualAugDataset
 
 class DCASE202XT2(object):
     def __init__(self, args):
@@ -58,12 +59,12 @@ class DCASE202XT2(object):
                 )
 
         train_index, valid_index = train_test_split(range(len(train_data)), test_size=args.validation_split)
-        self.train_dataset = Subset(train_data, train_index)
+        self.train_dataset = DualAugDataset(Subset(train_data, train_index), args.n_mels, args.frames)
         self.train_loader = torch.utils.data.DataLoader(
             self.train_dataset,
             batch_size=batch_size, shuffle=shuffle, batch_sampler=batch_sampler,
         )
-        self.valid_dataset   = Subset(train_data, valid_index)
+        self.valid_dataset   = DualAugDataset(Subset(train_data, valid_index), args.n_mels, args.frames)
         self.valid_loader = torch.utils.data.DataLoader(
             self.valid_dataset,
             batch_size=batch_size, shuffle=False, batch_sampler=batch_sampler,
@@ -95,7 +96,7 @@ class DCASE202XT2(object):
 
            self.test_loader.append(
                 torch.utils.data.DataLoader(
-                    _test_loader,
+                    DualAugDataset(_test_loader, args.n_mels, args.frames),
                     batch_size=_test_loader.n_vectors_ea_file, shuffle=False
                 )
            )

--- a/datasets/dual_augment.py
+++ b/datasets/dual_augment.py
@@ -1,0 +1,62 @@
+import numpy as np
+from torch.utils.data import Dataset
+from scipy.ndimage import zoom
+import random
+
+
+def _time_stretch(spec, rate):
+    """Simple time stretch on mel-spectrogram."""
+    stretched = zoom(spec, (1, rate), order=1)
+    T = spec.shape[1]
+    if stretched.shape[1] > T:
+        start = random.randint(0, stretched.shape[1] - T)
+        stretched = stretched[:, start:start+T]
+    else:
+        pad = T - stretched.shape[1]
+        stretched = np.pad(stretched, ((0,0),(0,pad)), mode='edge')
+    return stretched
+
+
+def _pitch_shift(spec, shift):
+    shifted = np.roll(spec, shift, axis=0)
+    if shift > 0:
+        shifted[:shift] = spec[0]
+    elif shift < 0:
+        shifted[shift:] = spec[-1]
+    return shifted
+
+
+def _add_noise(spec, scale=0.02):
+    noise = np.random.randn(*spec.shape) * scale
+    return spec + noise
+
+
+def random_aug(spec):
+    op = random.choice(['time', 'pitch', 'noise'])
+    if op == 'time':
+        rate = random.uniform(0.8, 1.2)
+        return _time_stretch(spec, rate)
+    if op == 'pitch':
+        shift = random.randint(-4, 4)
+        return _pitch_shift(spec, shift)
+    return _add_noise(spec)
+
+
+class DualAugDataset(Dataset):
+    """Wrap a dataset returning mel vectors to produce two augmented views."""
+    def __init__(self, base, n_mels, frames):
+        self.base = base
+        self.n_mels = n_mels
+        self.frames = frames
+
+    def __len__(self):
+        return len(self.base)
+
+    def __getitem__(self, idx):
+        data, y_true, cond, basename, index = self.base[idx]
+        spec = data.reshape(self.n_mels, self.frames)
+        a1 = random_aug(spec)
+        a2 = random_aug(spec)
+        pair = np.stack([a1, a2], axis=0)  # [2, n_mels, frames]
+        pair = pair[:, np.newaxis, :, :]     # [2, 1, n_mels, frames]
+        return pair, y_true, cond, basename, index


### PR DESCRIPTION
## Summary
- augment mel features twice per waveform for contrastive learning
- compute InfoNCE in BranchContrastive without machine labels
- normalise branch losses before fusion
- update training to handle augmented batches

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e7ddbb6ac8331902ad28875e71b55