### PR TITLE
Fix loss5 sign and balance branch losses

### DIFF
--- a/models/branch_flow.py
+++ b/models/branch_flow.py
@@ -12,4 +12,6 @@ class BranchFlow(nn.Module):
     def forward(self, z):
         logp = self.flow(z)
 
-        return -logp  # anomaly score
+        # return raw log-likelihood. The caller converts this to
+        # a positive loss via ``-logp``.
+        return logp


### PR DESCRIPTION
## Summary
- fix BranchFlow to return log likelihood and take negative in callers
- normalise autoencoder and flow losses using running means
- adjust branch 5 call sites with correct sign
- print branch losses during training
- use variance-only fusion loss

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e91e6ef64833194c3f5c567b9f3de