### PR TITLE
Fix AE training and flow ramp

### DIFF
--- a/common.py
+++ b/common.py
@@ -118,6 +118,8 @@ def get_argparse():
     parser.add_argument('--w4', type=float, default=1.0)
     parser.add_argument('--w5', type=float, default=1.0)
     parser.add_argument('--w5_start', type=float, default=0.01)
+    parser.add_argument('--w5_mid_epoch', type=float, default=40)
+    parser.add_argument('--w5_end_epoch', type=float, default=80)
     parser.add_argument('--w5_end', type=float, default=1.0)
     parser.add_argument('--w_fusion', type=float, default=0.1)
     parser.add_argument('--fusion_var_lambda', type=float, default=0.1)

--- a/config.yaml
+++ b/config.yaml
@@ -42,7 +42,7 @@ decoder_layers:       0      # number of decoder layers
 
 # 4. Embedding / diffusion / flow dims
 latent_dim:           16
-latent_noise_std: 0.1
+latent_noise_std: 0.2
 diffusion_unet_dim:   64
 diffusion_mults:     [1,2,4]
 diffusion_steps:    1000
@@ -55,10 +55,12 @@ batch_size: 32
 epochs:     100
 learning_rate: 1e-4
 w2:         1.0
-w3:         0.5
+w3:         2.0
 w4:         1.0
 w5:         1.0
 w5_start: 0.0
+w5_mid_epoch: 40
+w5_end_epoch: 80
 w5_end:   1.0
 w_fusion:    0.1
 fusion_var_lambda: 0.1

--- a/models/branch_transformer_ae.py
+++ b/models/branch_transformer_ae.py
@@ -61,7 +61,11 @@ class BranchTransformerAE(nn.Module):
             self.use_transformer_decoder = False
 
         # Final linear to reconstruct the mel-bin dimension
-        self.out = nn.Linear(config.hidden_size, cfg['n_mels'])
+        self.out = nn.Sequential(
+            nn.Linear(config.hidden_size, config.hidden_size),
+            nn.ReLU(),
+            nn.Linear(config.hidden_size, cfg['n_mels'])
+        )
 
     def forward(self, x):
         # x is [B, 1, n_mels, T] → [B, T, n_mels] for ASTModel

--- a/models/fusion_attention.py
+++ b/models/fusion_attention.py
@@ -9,8 +9,10 @@ class FusionAttention(nn.Module):
         super().__init__()
         # learnable branch weights
         self.attn = nn.Parameter(torch.ones(num_branches))
+        self.attn_weights = None
     def forward(self, scores):
         # scores: [B, num_branches]
         weights = torch.softmax(self.attn, dim=0)  # [num_branches]
+        self.attn_weights = weights.unsqueeze(0).expand(scores.size(0), -1)
         fused = (weights * scores).sum(dim=1)  # [B]
         return fused


### PR DESCRIPTION
## Summary
- ramp flow weight slower via new config params
- scale InfoNCE loss and raise latent noise
- add entropy regulariser in fusion module
- train AE only on source data
- keep running mean for source and normalise using it
- add small decoder MLP for AE

## Testing
- `python -m py_compile models/branch_transformer_ae.py models/fusion_attention.py networks/dcase2025_multi_branch/dcase2025_multi_branch.py common.py`

------
https://chatgpt.com/codex/tasks/task_e_684129cd3f288331af4b66615faa3d58