### PR TITLE
Enable mixed-type training with augmentations

### DIFF
--- a/01_train_2025t2.sh
+++ b/01_train_2025t2.sh
@@ -28,27 +28,10 @@ job="train_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyCar \
-        DCASE2025T2ToyTrain \
-        DCASE2025T2bearing \
-        DCASE2025T2fan \
-        DCASE2025T2gearbox \
-        DCASE2025T2slider \
-        DCASE2025T2valve \
-    "
+    dataset_list="DCASE2025T2ToyCar+DCASE2025T2ToyTrain+DCASE2025T2bearing+DCASE2025T2fan+DCASE2025T2gearbox+DCASE2025T2slider+DCASE2025T2valve"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyRCCar \
-        DCASE2025T2ToyPet \
-        DCASE2025T2HomeCamera \
-        DCASE2025T2AutoTrash \
-        DCASE2025T2Polisher \
-        DCASE2025T2ScrewFeeder \
-        DCASE2025T2BandSealer \
-        DCASE2025T2CoffeeGrinder \
-    "
+    dataset_list="DCASE2025T2ToyRCCar+DCASE2025T2ToyPet+DCASE2025T2HomeCamera+DCASE2025T2AutoTrash+DCASE2025T2Polisher+DCASE2025T2ScrewFeeder+DCASE2025T2BandSealer+DCASE2025T2CoffeeGrinder"
 fi
 
 for dataset in $dataset_list; do

--- a/02a_test_2025t2.sh
+++ b/02a_test_2025t2.sh
@@ -28,15 +28,7 @@ job="test_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyCar \
-        DCASE2025T2ToyTrain \
-        DCASE2025T2bearing \
-        DCASE2025T2fan \
-        DCASE2025T2gearbox \
-        DCASE2025T2slider \
-        DCASE2025T2valve \
-    "
+    dataset_list="DCASE2025T2ToyCar+DCASE2025T2ToyTrain+DCASE2025T2bearing+DCASE2025T2fan+DCASE2025T2gearbox+DCASE2025T2slider+DCASE2025T2valve"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
     echo dcase2025 task2 eval data are not publish

--- a/02b_test_2025t2.sh
+++ b/02b_test_2025t2.sh
@@ -28,15 +28,7 @@ job="test_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="\
-        DCASE2025T2ToyCar \
-        DCASE2025T2ToyTrain \
-        DCASE2025T2bearing \
-        DCASE2025T2fan \
-        DCASE2025T2gearbox \
-        DCASE2025T2slider \
-        DCASE2025T2valve \
-    "
+    dataset_list="DCASE2025T2ToyCar+DCASE2025T2ToyTrain+DCASE2025T2bearing+DCASE2025T2fan+DCASE2025T2gearbox+DCASE2025T2slider+DCASE2025T2valve"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
     echo dcase2025 task2 eval data are not publish

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ ast_model: MIT/ast-finetuned-audioset-10-10-0.4593
 device: 'cuda'
 
 # 1. General parameters
-model: DCASE2025MultiBranch
+model: ASTAutoencoderASD
 use_cuda: True
 score: MSE
 seed: 13711

--- a/datasets/loader_common.py
+++ b/datasets/loader_common.py
@@ -61,7 +61,7 @@ __versions__ = "1.0.0"
 ########################################################################
 # download dataset parameter
 ########################################################################
-DATA_ROOT = "/lustre1/g/geog_pyloo/11_octa/dcase2023_task2_baseline_ae"
+DATA_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DOWNLOAD_PATH_YAML_DICT = {
     "DCASE2025T2":f"{DATA_ROOT}/datasets/download_path_2025.yaml",
     "DCASE2024T2":f"{DATA_ROOT}/datasets/download_path_2024.yaml",

--- a/test_ae.sh
+++ b/test_ae.sh
@@ -28,4 +28,4 @@ python3 train.py \
     --use_ids ${id} \
     --score ${score} \
     --test_only
-    
+


### PR DESCRIPTION
## Summary
- support multi‑machine training through `MultiDCASE202XT2`
- mix machine types when running train/test scripts
- use AST model by default
- make dataset paths relative

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: /workspace/dcase2025-asd/data/dcase2025t2/dev_data/raw/ToyCar/train is not directory and do not use auto download)*
- `bash 02a_test_2025t2.sh -d` *(fails: /workspace/dcase2025-asd/data/dcase2025t2/dev_data/raw/ToyCar/train is not directory and do not use auto download)*

------
https://chatgpt.com/codex/tasks/task_e_684525806b6483318f128f3216543c51