### PR TITLE
Fix per machine type inference

### DIFF
--- a/02a_test_2025t2.sh
+++ b/02a_test_2025t2.sh
@@ -28,7 +28,7 @@ job="test_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="DCASE2025T2ToyCar+DCASE2025T2ToyTrain+DCASE2025T2bearing+DCASE2025T2fan+DCASE2025T2gearbox+DCASE2025T2slider+DCASE2025T2valve"
+    dataset_list="DCASE2025T2ToyCar DCASE2025T2ToyTrain DCASE2025T2bearing DCASE2025T2fan DCASE2025T2gearbox DCASE2025T2slider DCASE2025T2valve"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
     echo dcase2025 task2 eval data are not publish

--- a/02b_test_2025t2.sh
+++ b/02b_test_2025t2.sh
@@ -28,7 +28,7 @@ job="test_ae.sh"
 
 if [ "${dev_eval}" = "-d" ] || [ "${dev_eval}" = "--dev" ]
 then
-    dataset_list="DCASE2025T2ToyCar+DCASE2025T2ToyTrain+DCASE2025T2bearing+DCASE2025T2fan+DCASE2025T2gearbox+DCASE2025T2slider+DCASE2025T2valve"
+    dataset_list="DCASE2025T2ToyCar DCASE2025T2ToyTrain DCASE2025T2bearing DCASE2025T2fan DCASE2025T2gearbox DCASE2025T2slider DCASE2025T2valve"
 elif [ "${dev_eval}" = "-e" ] || [ "${dev_eval}" = "--eval" ]
 then
     echo dcase2025 task2 eval data are not publish


### PR DESCRIPTION
## Summary
- export each machine type separately during testing

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: dataset not found)*
- `bash 02b_test_2025t2.sh -d` *(fails: dataset not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453885fb088331a37cca7e181dd662