### PR TITLE
Fix dataset mode for training-only runs

### DIFF
--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -17,6 +17,8 @@ class DCASE202XT2(object):
         shuffle = args.shuffle
         batch_sampler = None
         batch_size = args.batch_size
+        # dev/eval mode flag used by some loaders
+        self.mode = args.dev
         print("input dim: %d" % (self.input_dim))
 
         dataset_name = args.dataset[:11]


### PR DESCRIPTION
## Summary
- ensure `DCASE202XT2` has a `mode` field even when using `--train_only`

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845a6381dcc833197eab01a895b6ca3