### PR TITLE
Improve decoder reconstruction

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -29,11 +29,12 @@ class ASTAutoencoder(nn.Module):
         self,
         latent_dim: int = 128,
         n_mels: int = 128,
+        time_steps: int = 512,
         alpha: float = 0.5,
     ) -> None:
         super().__init__()
         self.encoder = ASTEncoder(latent_dim=latent_dim)
-        self.decoder = SpectroDecoder(latent_dim=latent_dim, n_mels=n_mels)
+        self.decoder = SpectroDecoder(latent_dim=latent_dim, n_mels=n_mels, time_steps=time_steps)
         self.alpha = alpha
 
         # Mean and precision for Mahalanobis – initialised later via `fit_stats`.
@@ -144,7 +145,13 @@ class ASTAutoencoderASD(BaseModel):
         self.device = "cuda" if self.args.use_cuda and torch.cuda.is_available() else "cpu"
         latent = cfg.get("latent_dim", 128)
         alpha = cfg.get("alpha", 0.5)
-        return ASTAutoencoder(latent_dim=latent, n_mels=self.data.height, alpha=alpha)
+        time_steps = cfg.get("time_steps", 512)
+        return ASTAutoencoder(
+            latent_dim=latent,
+            n_mels=self.data.height,
+            time_steps=time_steps,
+            alpha=alpha,
+        )
 
     def __init__(self, args, train, test):
         super().__init__(args=args, train=train, test=test)


### PR DESCRIPTION
## Summary
- learn entire spectrogram in `SpectroDecoder`
- support configurable `time_steps` in `ASTAutoencoder`
- pass `time_steps` from training args

## Testing
- `python -m py_compile models/branch_decoder.py networks/dcase2025_singlebranch/ast_ae.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b351f3948331a06d244f5cae1381