### PR TITLE
Freeze encoder layers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ result_directory: ./results
 save_dir: ./checkpoints
 export_dir: ast_singlebranch
 ast_model: MIT/ast-finetuned-audioset-10-10-0.4593
+ast_freeze_layers: 10
 
 # ─ General ──────────────────────────────────────────────
 model: ASTAutoencoderASD
@@ -29,7 +30,7 @@ latent_noise_std: 0.05
 # ─ Training ─────────────────────────────────────────────
 batch_size: 16        # adjust to GPU RAM
 epochs: 50
-learning_rate: 3e-5   # full fine-tune; if encoder partly frozen you can go 1e-4
+learning_rate: 1e-4   # full fine-tune may use 3e-5; with frozen layers 1e-4 works well
 validation_split: 0.1
 num_workers: 4
 shuffle: true

--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -34,7 +34,8 @@ class ASTAutoencoder(nn.Module):
         latent_noise_std: float = 0.0,
     ) -> None:
         super().__init__()
-        self.encoder = ASTEncoder(latent_dim=latent_dim)
+        freeze_layers = cfg.get("ast_freeze_layers", 0)
+        self.encoder = ASTEncoder(latent_dim=latent_dim, freeze_layers=freeze_layers)
         self.decoder = SpectroDecoder(latent_dim=latent_dim, n_mels=n_mels, time_steps=time_steps)
         self.alpha = alpha
         self.latent_noise_std = latent_noise_std


### PR DESCRIPTION
## Summary
- freeze first 10 transformer layers in `ASTEncoder`
- expose freeze count via `ast_freeze_layers` in YAML and hook up in `ASTAutoencoder`
- raise learning rate to `1e-4`

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846400a89408331834945c53507707f