### PR TITLE
Fix AST encoder layer freezing and positional embeddings

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -36,7 +36,12 @@ class ASTAutoencoder(nn.Module):
     ) -> None:
         super().__init__()
         freeze_layers = cfg.get("ast_freeze_layers", 0)
-        self.encoder = ASTEncoder(latent_dim=latent_dim, freeze_layers=freeze_layers)
+        self.encoder = ASTEncoder(
+            latent_dim=latent_dim,
+            freeze_layers=freeze_layers,
+            n_mels=n_mels,
+            T_fix=time_steps,
+        )
         self.decoder = SpectroDecoder(latent_dim=latent_dim, n_mels=n_mels, time_steps=time_steps)
         self.alpha = alpha
         self.latent_noise_std = latent_noise_std


### PR DESCRIPTION
## Summary
- crop AST positional embeddings on load to match mel/time dimensions
- freeze initial AST parameters via index and support customizing freeze depth
- allow passing mel/time dimensions through to encoder

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684645d57f688331adc30448396eded0