### PR TITLE
Configure two learning rates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ latent_noise_std: 0.05
 # ─ Training ─────────────────────────────────────────────
 batch_size: 16        # adjust to GPU RAM
 epochs: 50
-learning_rate: 1e-4   # full fine-tune may use 3e-5; with frozen layers 1e-4 works well
+learning_rate: 3e-5   # encoder lr; decoder & projection use 1e-4
 validation_split: 0.1
 num_workers: 4
 shuffle: true

--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -169,7 +169,15 @@ class ASTAutoencoderASD(BaseModel):
 
     def __init__(self, args, train, test):
         super().__init__(args=args, train=train, test=test)
-        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=self.args.learning_rate)
+        dec_params = list(self.model.decoder.parameters())
+        proj_params = list(self.model.encoder.proj.parameters())
+        enc_params = [p for p in self.model.encoder.ast.parameters() if p.requires_grad]
+        self.optimizer = torch.optim.Adam(
+            [
+                {"params": dec_params + proj_params, "lr": 1e-4},
+                {"params": enc_params, "lr": self.args.learning_rate},
+            ]
+        )
         self.ema_scores = []
         self.noise_enabled = False
         self.model.latent_noise_std = 0.0


### PR DESCRIPTION
## Summary
- update training config with new default lr
- train decoder and projection head at higher lr using optimizer parameter groups

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68464855e084833185059534880d1d86