### PR TITLE
Add resume_last option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ personalpages.surrey.ac.uk
 
 # Train the model
 ```bash train_ae.sh -d```
+# Resume training from the last checkpoint
+```bash
+python train.py --resume_last
+```
 # Debugging
 Use `debug_freeze.py` to freeze a single branch and inspect the training behaviour. Example:
 

--- a/common.py
+++ b/common.py
@@ -169,5 +169,8 @@ def get_argparse():
                         help='Run train only')
     parser.add_argument('--test_only', action='store_true', default=False,
                         help='Run test only')
-    
+
+    parser.add_argument('--resume_last', action='store_true',
+                        help='Resume from the most recent checkpoint')
+
     return parser

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,7 @@ learning_rate: 3e-5   # encoder lr; decoder & projection use 1e-4
 validation_split: 0.1
 num_workers: 4
 shuffle: true
+resume_last: false
 
 # ─ Data augmentation ───────────────────────────────────
 specaug_freq_mask: 16

--- a/networks/base_model.py
+++ b/networks/base_model.py
@@ -49,6 +49,11 @@ class BaseModel(object):
         Path(self.checkpoint_dir).mkdir(parents=True, exist_ok=True)
         self.checkpoint_path = f"{self.checkpoint_dir}/checkpoint.tar"
         Path(f"models/checkpoint/{self.export_dir}").mkdir(parents=True, exist_ok=True)
+        if self.args.resume_last:
+            ckpt_list = sorted(Path(self.checkpoint_dir).glob('*.tar'), key=os.path.getmtime)
+            if ckpt_list:
+                self.args.restart = True
+                self.args.checkpoint_path = str(ckpt_list[-1])
         self.logs_dir = Path(f"logs/{base_name}")
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.log_path = self.logs_dir / "log.csv"


### PR DESCRIPTION
## Summary
- add a `resume_last` flag to pick up the latest checkpoint
- automatically set restart/checkpoint path when `resume_last` is used
- document how to resume training

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684682d7d0648331b203ce296c335162