### PR TITLE
Fix checkpoint path error in ASTAE

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -323,8 +323,9 @@ class ASTAutoencoderASD(BaseModel):
 
         else:
             # save model and optimizer state for resuming training
-            if not os.path.exists(self.checkpoint_path.parent):
-                os.makedirs(self.checkpoint_path.parent)
+            checkpoint_path = Path(self.checkpoint_path)
+            if not checkpoint_path.parent.exists():
+                checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
             torch.save(
                 {
                     "epoch": epoch,
@@ -333,7 +334,7 @@ class ASTAutoencoderASD(BaseModel):
                     "scheduler_state_dict": self.scheduler.state_dict(),
                     "loss": avg_train,
                 },
-                self.checkpoint_path,
+                checkpoint_path,
             )
 
     def test(self):


### PR DESCRIPTION
## Summary
- prevent `'str' object has no attribute 'parent'` by converting `checkpoint_path` to `Path`
- run project scripts to check for errors

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846912b194483319f2de1a4410dc534