### PR TITLE
Fix fit_stats_streaming loader handling

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -84,10 +84,11 @@ class ASTAutoencoder(nn.Module):
     @torch.no_grad()
     def fit_stats_streaming(self, loader):
         mean = torch.zeros(self.mu.shape, device=self.mu.device)
-        M2   = torch.zeros_like(self.inv_cov)
+        M2 = torch.zeros_like(self.inv_cov)
         n = 0
-        for xb, _ in loader:
-            z = self.encoder(xb.to(self.mu.device))
+        for batch in loader:
+            xb = batch[0].to(self.mu.device)
+            z = self.encoder(xb)
             for zi in z:
                 n += 1
                 delta = zi - mean


### PR DESCRIPTION
## Summary
- fix DataLoader iteration in `fit_stats_streaming` to handle 4-element batches

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846981a6efc83318d52d9e668d2c78d