### PR TITLE
Fix dtype mismatch during final statistics calculation

### DIFF
--- a/models/branch_astencoder.py
+++ b/models/branch_astencoder.py
@@ -73,6 +73,7 @@ class ASTEncoder(nn.Module):
                     param.requires_grad = False
 
     def forward(self, x: Tensor) -> Tensor:
+        x = x.float()
         # Undo zero‑mean/unit‑var normalisation with a learnable affine
         x = x * self.input_scale + self.input_bias
         x = x.squeeze(1)  # [B, n_mels, T] – AST expects channel dim last

--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -73,7 +73,7 @@ class ASTAutoencoder(nn.Module):
         zs: List[Tensor] = []
         device = next(self.parameters()).device
         for xb, _ in dataloader:
-            xb = xb.to(device)
+            xb = xb.to(device).float()
             z = self.encoder(xb)
             zs.append(z)
         z_all = torch.cat(zs, dim=0)
@@ -87,7 +87,7 @@ class ASTAutoencoder(nn.Module):
         M2 = torch.zeros_like(self.inv_cov)
         n = 0
         for batch in loader:
-            xb = batch[0].to(self.mu.device)
+            xb = batch[0].to(self.mu.device).float()
             z = self.encoder(xb)
             for zi in z:
                 n += 1


### PR DESCRIPTION
## Summary
- ensure ASTEncoder input is float32
- cast batches to float32 when computing latent statistics

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68469d6f7c908331bab6898c41d023d9