### PR TITLE
Fix state dict loading in test

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -341,7 +341,11 @@ class ASTAutoencoderASD(BaseModel):
     def test(self):
         device = self.device
         if os.path.exists(self.model_path):
-            self.model.load_state_dict(torch.load(self.model_path, map_location=device))
+            checkpoint = torch.load(self.model_path, map_location=device)
+            if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+                self.load_state_dict(checkpoint)
+            else:
+                self.model.load_state_dict(checkpoint)
         self.model.eval()
 
         decision_thresholds = self.calc_decision_threshold()


### PR DESCRIPTION
## Summary
- improve AST autoencoder test loading

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846a40586308331b8c0cadd6115b0a9