### PR TITLE
Fix loading of saved state dicts

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -345,7 +345,12 @@ class ASTAutoencoderASD(BaseModel):
             if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
                 self.load_state_dict(checkpoint)
             else:
-                self.model.load_state_dict(checkpoint)
+                # adapt checkpoints saved as plain state_dict
+                self.load_state_dict({
+                    "model_state_dict": checkpoint,
+                    "epoch": 0,
+                    "loss": 0,
+                })
         self.model.eval()
 
         decision_thresholds = self.calc_decision_threshold()


### PR DESCRIPTION
## Summary
- fix checkpoint loading for AST autoencoder

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846a6a3ceec833195d74b3e12704003