### PR TITLE
Fix ASTEncoder positional embedding handling

### DIFF
--- a/models/branch_astencoder.py
+++ b/models/branch_astencoder.py
@@ -1,20 +1,8 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch import Tensor
 from transformers import ASTModel
 
-def _resize_position_embeddings(old_emb: torch.Tensor, seq_len: int) -> torch.Tensor:
-    """Interpolate or crop positional embeddings to the desired length."""
-    old_len = old_emb.size(1)
-    if seq_len == old_len:
-        return old_emb
-    if seq_len < old_len:
-        return old_emb[:, :seq_len, :].clone()
-    # interpolate to longer length
-    emb_t = old_emb.permute(0, 2, 1)  # [1, d, L]
-    new_emb = F.interpolate(emb_t, size=seq_len, mode="linear", align_corners=False)
-    return new_emb.permute(0, 2, 1)
 
 # -----------------------------------------------------------------------------
 # 1. Encoder: Pre‑trained AST (Audio Spectrogram Transformer) fine‑tuned on the
@@ -54,13 +42,6 @@ class ASTEncoder(nn.Module):
 
         self.proj = nn.Linear(self.ast.config.hidden_size, latent_dim)
 
-        # keep a copy of the original positional embeddings for resizing later
-        self.register_buffer(
-            "_orig_pos",
-            self.ast.embeddings.position_embeddings.detach().clone(),
-            persistent=False,
-        )
-
         # Freeze parameters according to transformer block index
         for name, p in self.ast.named_parameters():
             if not fine_tune:
@@ -78,18 +59,8 @@ class ASTEncoder(nn.Module):
         x = x * self.input_scale + self.input_bias
         x = x.squeeze(1)  # [B, n_mels, T] – AST expects channel dim last
 
-        # Adapt positional embeddings dynamically to the sequence length
-        _, n_mels, T = x.shape
-        ps = self.ast.config.patch_size
-        fs = self.ast.config.frequency_stride
-        ts = self.ast.config.time_stride
-        H = (n_mels - ps) // fs + 1
-        W = (T - ps) // ts + 1
-        seq_len = 2 + H * W
-
-        if self.ast.embeddings.position_embeddings.size(1) != seq_len:
-            resized = _resize_position_embeddings(self._orig_pos, seq_len)
-            self.ast.embeddings.position_embeddings = nn.Parameter(resized)
+        # Positional embeddings have been resized once in ``__init__``.
+        # All inputs are expected to be padded/cropped to ``T_fix`` beforehand.
 
         out = self.ast(input_values=x)
         cls_emb = out.last_hidden_state[:, 0]  # CLS token


### PR DESCRIPTION
## Summary
- remove dynamic resize logic from `ASTEncoder`
- positional embeddings are set once during init

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68479e26ffbc83318f691faefa7173dd