### PR TITLE
Fix AST freeze logic and decoder size check

### DIFF
--- a/models/branch_astencoder.py
+++ b/models/branch_astencoder.py
@@ -50,12 +50,9 @@ class ASTEncoder(nn.Module):
         for name, p in self.ast.named_parameters():
             if not fine_tune:
                 p.requires_grad = False
-                continue
-            if name.startswith("encoder.layer"):
+            elif name.startswith("encoder.layer"):
                 blk = int(name.split(".")[2])
                 p.requires_grad = blk >= freeze_layers
-            else:
-                p.requires_grad = freeze_layers <= 0
 
     def forward(self, x: Tensor) -> Tensor:
         x = x.float()

--- a/models/branch_decoder.py
+++ b/models/branch_decoder.py
@@ -18,6 +18,9 @@ class SpectroDecoder(nn.Module):
         super().__init__()
         self.n_mels = n_mels
         self.time_steps = time_steps
+        assert (
+            time_steps % 4 == 0
+        ), "time_steps must be divisible by 4 (decoder upsample)."
         self.net = nn.Sequential(
             nn.Linear(latent_dim, 64 * (time_steps // 4)),
             nn.ReLU(True),


### PR DESCRIPTION
## Summary
- freeze AST layers by transformer block index to ensure consistent fine-tuning
- enforce that decoder time dimension is divisible by four

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6847acb2d72483318c78b85c65c75808