### PR TITLE
Fix machine type metadata for gamma calibration

### DIFF
--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -36,6 +36,9 @@ class DCASE202XT2(object):
 
         dataset_name = args.dataset[:11]
         machine_type = args.dataset[11:]
+        self.dataset_name = dataset_name
+        self.machine_type = machine_type
+        self.dataset_str = f"{dataset_name}{machine_type}"
         if args.eval:
             data_path = f'{args.dataset_directory}/{dataset_name.lower()}/eval_data/'
             data_type = "eval"


### PR DESCRIPTION
## Summary
- set `dataset_name`, `machine_type`, and `dataset_str` in `DCASE202XT2` dataset

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6847f8b568a48331974e629053615fd0