### PR TITLE
Fix device mismatch error in ASTAutoencoderASD

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -221,8 +221,10 @@ class ASTAutoencoderASD(BaseModel):
 
     def __init__(self, args, train, test):
         super().__init__(args=args, train=train, test=test)
-        # ---------- build the model ----------
-        self.model = self.init_model()           # ← creates AST encoder/decoder
+        # ``BaseModel`` already initialises ``self.model`` and moves it to the
+        # correct device, so avoid re-creating it here.  Re-initialising the
+        # model would leave it on the CPU and lead to device mismatch errors
+        # during training.
         # ---------- DEBUG: check how many AST params can learn ----------
         n_trainable = sum(p.requires_grad
                           for p in self.model.encoder.ast.parameters())


### PR DESCRIPTION
## Summary
- stop reinitializing the model in `ASTAutoencoderASD.__init__`
- explain why in comments

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68491939947c8331afd834f1450407e1