### PR TITLE
Fix trainable parameter count

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -226,8 +226,7 @@ class ASTAutoencoderASD(BaseModel):
         # model would leave it on the CPU and lead to device mismatch errors
         # during training.
         # ---------- DEBUG: check how many AST params can learn ----------
-        n_trainable = sum(p.requires_grad
-                          for p in self.model.encoder.ast.parameters())
+        n_trainable = sum(p.numel() for p in self.model.encoder.ast.parameters() if p.requires_grad)
         print("[DEBUG] trainable AST params:", n_trainable)
         # should be > 0  (about 22 M if 12 of 24 layers are unfrozen)
         
@@ -372,8 +371,7 @@ class ASTAutoencoderASD(BaseModel):
         # print("mean =", w.mean().item(), "std =", w.std().item())
         # print("DEBUGGING: AST encoder parameters:")
         if epoch == 1 or epoch == self._warmup_epochs + 1:   # print twice
-            n_trainable = sum(p.requires_grad
-                            for p in self.model.encoder.ast.parameters())
+            n_trainable = sum(p.numel() for p in self.model.encoder.ast.parameters() if p.requires_grad)
             print(f"[DEBUG] epoch {epoch}: trainable AST params = {n_trainable}")
             
         self.model.train()


### PR DESCRIPTION
## Summary
- fix debug print so AST parameter count matches total elements

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684929ae31448331b4d6dad5c799e2a3