### PR TITLE
Enable AST freezing warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ personalpages.surrey.ac.uk
 ```bash 01_train_2025t2.sh -d```
 # Resume training from the last checkpoint
 ```bash 01_train_2025t2.sh --restart```
+# Freeze the AST encoder for N warm-up epochs
+```bash 01_train_2025t2.sh --warm_up_epochs N```
 # Test on the development set
 ```bash 02a_test_2025t2.sh -d```
 

--- a/common.py
+++ b/common.py
@@ -134,6 +134,8 @@ def get_argparse():
     parser.add_argument('--noise_p', type=float, default=0.5)
     parser.add_argument('--latent_noise_std', type=float, default=0.0)
     parser.add_argument('--ast_freeze_layers', type=int, default=12)
+    parser.add_argument('--warm_up_epochs', type=int, default=0,
+                        help='Number of epochs to keep AST encoder frozen')
 
     # dataset
     parser.add_argument('--dataset_directory', type=str, default='data',

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ save_dir: ./checkpoints
 export_dir: ast_singlebranch
 ast_model: MIT/ast-finetuned-audioset-10-10-0.4593
 ast_freeze_layers: 12
+warm_up_epochs: 0
 
 # ─ General ──────────────────────────────────────────────
 model: ASTAutoencoderASD

--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -258,8 +258,10 @@ class ASTAutoencoderASD(BaseModel):
         self._orig_ast_requires_grad = {
             n: p.requires_grad for n, p in self.model.encoder.ast.named_parameters()
         }
-        self._warmup_epochs = 0        # no blanket freeze
+        self._warmup_epochs = getattr(self.args, "warm_up_epochs", 0)
         self._ast_frozen = False
+        if self._warmup_epochs > 0:
+            self._freeze_ast()
 
     # --------------------------------------------------------------
     # Utility helpers to temporarily disable SpecAugment


### PR DESCRIPTION
## Summary
- allow freezing the AST encoder for a warm-up period
- expose `--warm_up_epochs` argument and config option
- document warm-up argument in README

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68492ae83cac8331adb836c09c2f4db8