### PR TITLE
Fix AST encoder freeze logic

### DIFF
--- a/models/branch_astencoder.py
+++ b/models/branch_astencoder.py
@@ -50,7 +50,18 @@ class ASTEncoder(nn.Module):
         for name, p in self.ast.named_parameters():
             if not fine_tune:
                 p.requires_grad = False
-            if not name.startswith("encoder.layer"):
+                continue
+
+            if name.startswith("encoder.layer."):
+                try:
+                    layer_idx = int(name.split(".")[2])
+                except (IndexError, ValueError):
+                    layer_idx = None
+                if layer_idx is not None:
+                    p.requires_grad = layer_idx >= freeze_layers
+                else:
+                    p.requires_grad = freeze_layers <= 0
+            else:
                 p.requires_grad = freeze_layers <= 0
 
     def forward(self, x: Tensor) -> Tensor:


### PR DESCRIPTION
## Summary
- ensure freeze_layers actually freezes early transformer blocks

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68492cdfd1708331b38fbf6a0c4f3033