### PR TITLE
Add latent variance debug prints

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -114,6 +114,20 @@ class ASTAutoencoder(nn.Module):
         self.mu.copy_(mean)
         self.inv_cov.copy_(torch.linalg.inv(cov))
 
+        var = torch.diagonal(cov)
+        print(
+            "latent var  min/mean/max",
+            var.min().item(),
+            var.mean().item(),
+            var.max().item(),
+        )
+        print(
+            "latent std  min/mean/max",
+            torch.sqrt(var).min().item(),
+            torch.sqrt(var).mean().item(),
+            torch.sqrt(var).max().item(),
+        )
+
         # Compute Mahalanobis distance statistics for z-scoring
         dists = []
         recon_errs = []


### PR DESCRIPTION
## Summary
- add debug prints to show latent variance and std in `fit_stats_streaming`

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a33d637c48331b3e34d02a97a1e45