### PR TITLE
Fix clean_loader alignment

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -573,19 +573,6 @@ class ASTAutoencoderASD(BaseModel):
                 )
                 self.model.latent_noise_std = self._latent_noise_base
 
-                # ----------------------------------------------------------
-                # Verify only normal samples are used for statistics fitting
-                # and inspect which section IDs are present.  ``clean_loader``
-                # yields batches in the legacy format
-                # ``(feat, label, cond, name)``.
-                # ----------------------------------------------------------
-                anomaly_counter = 0
-                section_ids: set[int] = set()
-                for b in clean_loader:
-                    labels = b[1]
-                    conds = b[2]
-                    anomaly_counter += (labels == 1).sum().item()
-                    section_ids.update(conds.argmax(dim=1).tolist())
                 self.model.fit_stats_streaming(clean_loader)
                 self.model.latent_noise_std = self._latent_noise_base # keep noise for testing
 


### PR DESCRIPTION
## Summary
- remove verification loop that iterated `clean_loader` before fitting statistics

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684abaeb9e7c833186544fc264340834