### PR TITLE
Fix fit_stats_streaming for datasets without filenames

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -125,7 +125,10 @@ class ASTAutoencoder(nn.Module):
                 attr = None
                 names = rest[1]                 # basename list is last element
             recon, z, mse = self.forward(xb, attr_vec=attr)
-            ids_all.extend([1 if "target" in n.lower() else 0 for n in names])
+            if isinstance(names, (list, tuple)) and names and isinstance(names[0], str):
+                ids_all.extend([1 if "target" in n.lower() else 0 for n in names])
+            else:
+                ids_all.extend([0] * xb.size(0))
 
             z_d = z.double()
 


### PR DESCRIPTION
## Summary
- handle datasets that do not return filenames in `fit_stats_streaming`

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ac0958cd88331863ee77b4069cf71