### PR TITLE
Apply log-scaling to reconstruction error

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ power: 2
 
 # ─ Model hyperparams ───────────────────────────────────
 latent_dim: 64        # 16|64|128 → pick after ablation
-alpha: 0.7            # fusion weight
+alpha: 0.9            # fusion weight
 latent_noise_std: 0.05
 
 # ─ Training ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- robustify reconstruction MSE via `log10`
- lower reconstruction weight (alpha)

## Testing
- `python -m py_compile networks/dcase2025_singlebranch/ast_ae.py`
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684ae568c4c48331b53372214c02bb6c