### PR TITLE
Implement missing mahalanobis computation

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -113,6 +113,12 @@ class ASTAutoencoder(nn.Module):
         self.mse_med.zero_()
         self.mse_mad.fill_(1.0)
 
+    def mahalanobis(self, z: Tensor) -> Tensor:
+        """Return whitened Mahalanobis distance for latent vectors ``z``."""
+        delta = z - self.mu
+        delta = delta / torch.sqrt(self.cov + 1e-6)
+        return torch.linalg.norm(delta, dim=1)
+
     # ------------------------------------------------------------------
     # Statistics fitting – call once on *normal* training data.
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a `mahalanobis` method for whitened distance calculation

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684bfc1e28908331a816d09ad0ae4b7f