### PR TITLE
Add gradient logging when AST unfreezes

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -455,6 +455,10 @@ class ASTAutoencoderASD(BaseModel):
             loss = (mse * weights).mean()
             self.optimizer.zero_grad()
             loss.backward()
+            if not self._ast_frozen:
+                for n, p in self.model.encoder.ast.named_parameters():
+                    if p.grad is not None:
+                        print(n, p.grad.abs().mean())
             self.optimizer.step()
 
             is_source = ~is_target


### PR DESCRIPTION
## Summary
- log mean gradient for each AST parameter once unfrozen

## Testing
- `bash 01_train_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c3137d27483318abb18597eecf897