### PR TITLE
Fix AST reconstruction padding mismatch

### DIFF
--- a/networks/dcase2025_singlebranch/ast_ae.py
+++ b/networks/dcase2025_singlebranch/ast_ae.py
@@ -447,7 +447,14 @@ class ASTAutoencoderASD(BaseModel):
         with torch.no_grad():
             for idx in idxs:
                 sample = dataset[idx]
-                feat = sample[0].to(self.device)  # [1, n_mels, T]
+                feat = sample[0]
+                if feat.shape[-1] != self.model.decoder.time_steps:
+                    pad = self.model.decoder.time_steps - feat.shape[-1]
+                    if pad > 0:
+                        feat = F.pad(feat, (0, pad))
+                    else:
+                        feat = feat[..., : self.model.decoder.time_steps]
+                feat = feat.to(self.device)
                 attr = None
                 if self.model.use_attribute and len(sample) > 1 and isinstance(sample[1], torch.Tensor) and sample[1].numel() > 0:
                     attr = sample[1].unsqueeze(0).to(self.device)


### PR DESCRIPTION
## Summary
- pad/truncate variable-length samples in `_save_recon_samples` to match the model's fixed time dimension

## Testing
- `bash 02a_test_2025t2.sh -d` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c41b8e3bc833186e5b377cd607057